### PR TITLE
表示領域にコンテンツが収まっているのに縦・横スクロール出来る事象を修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,11 +15,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <div className="flex flex-row h-screen">
-          <div className='fixed top-0 left-0'>
+        <div className="flex">
+          <div className='flex-none'>
             <SideBar />
           </div>
-          <div className='fixed top-0 left-64 w-screen h-screen pb-40'>{children}</div>
+          <div className='flex-auto'>{children}</div>
         </div>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,7 @@
 export default function Home() {
-  return <></>
+  return (
+    <div className="flex justify-center">
+      <p className="text-2xl">こんにちは、◯◯さん</p>
+    </div>
+  )
 }


### PR DESCRIPTION
# Overview
要素をインライン化した際に横スライドさせるとスクロール出来てしまう事象
この時要素のwidthは表示領域に収まっているが発生していた

## Cause
flex指定方法を誤っていた事による起因