### PR TITLE
Remove enviroment variables from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky",
-    "format": "npx prettier $PATH --write"
+    "format": "npx prettier --write"
   },
   "lint-staged": {
     "**/*": "npx prettier --write --ignore-unknown"


### PR DESCRIPTION
# Overview
npm run format [ ファイルパス ]を実行した際にパスの引数を受け取る為に環境変数をscriptsに埋め込んでいたが
認識齟齬で使用していなかったのが判明した為、削除対応